### PR TITLE
Use pathlib to make paths platform-independent

### DIFF
--- a/goal.py
+++ b/goal.py
@@ -6,7 +6,7 @@ from settings import *
 class Goal(pygame.sprite.Sprite):
     def __init__(self) -> None:
         super().__init__()
-        self.frames = get_frames("images\\goal")
+        self.frames = get_frames(Path(r"./images/goal"))
         self.frame_index = 0
         self.animation_speed = .15
         pos = TILE_SIZE * MAZE_SIZE - TILE_SIZE // 2 

--- a/player.py
+++ b/player.py
@@ -7,8 +7,8 @@ from support import get_frames
 class Player(pygame.sprite.Sprite):
     def __init__(self) -> None:
         super().__init__()
-        self.walk_frames = get_frames("images\\player\\walk")
-        self.stand_frames = get_frames("images\\player\\stand")
+        self.walk_frames = get_frames(Path(r"./images/player/walk"))
+        self.stand_frames = get_frames(Path(r"./images/player/stand"))
         self.frames = self.stand_frames
         self.frame_index = 0
         self.animation_speed = 0.2

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 
 SCREEN_SIZE = 700
 MAZE_SIZE = 10
@@ -13,7 +14,7 @@ ENEMY_RATE = 100
 # CELL_COLOR = "goldenrod"
 # EXT_COLOR = "darkgreen"
 
-ENEMIES_PATH = ["images\\enemies\\1", "images\\enemies\\2"] 
-WALL_IMAGE = "images\\maze\\wall4.png"
-FLOOR_IMAGE = "images\\maze\\floor4.png"
-OUTSIDE_IMAGE = "images\\maze\\outside2.png"
+ENEMIES_PATH = [Path(r"./images/enemies/1"), Path(r"./images/enemies/2")] 
+WALL_IMAGE = Path(r"./images/maze/wall4.png")
+FLOOR_IMAGE = Path(r"./images/maze/floor4.png")
+OUTSIDE_IMAGE = Path(r"./images/maze/outside2.png")

--- a/support.py
+++ b/support.py
@@ -6,7 +6,8 @@ def get_frames(path) -> list[pygame.Surface]:
     frames = []
     for _, __, files in walk(path):
         for file in files:
-            image = pygame.image.load(path +"\\" + file).convert_alpha()
+            file_path = path / file
+            image = pygame.image.load(file_path).convert_alpha()
             image = pygame.transform.scale2x(image)
             frames.append(image)
     return frames


### PR DESCRIPTION
Estos cambios usan pathlib en lugar de las rutas a archivos fijas para Windows. De esta forma, las rutas relativas a los archivos funcionan para todos los sistemas operativos.